### PR TITLE
Add m7 chords

### DIFF
--- a/src/db/guitar/chords/A/m7.js
+++ b/src/db/guitar/chords/A/m7.js
@@ -11,6 +11,15 @@ export default {
       fingers: '002314'
     },
     {
+      frets: '5x555x',
+      fingers: '203330'
+    },
+    {
+      frets: 'x05555',
+      fingers: '001111',
+      barres: 5
+    },
+    {
       frets: '575555',
       fingers: '131111',
       barres: 5,

--- a/src/db/guitar/chords/Ab/m7.js
+++ b/src/db/guitar/chords/Ab/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '4x444x',
+      fingers: '203330'
+    },
+    {
       frets: '464444',
       fingers: '131111',
       barres: 4,

--- a/src/db/guitar/chords/B/m7.js
+++ b/src/db/guitar/chords/B/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '7x777x',
+      fingers: '203330'
+    },
+    {
       frets: '224232',
       fingers: '113121',
       barres: 2,

--- a/src/db/guitar/chords/Bb/m7.js
+++ b/src/db/guitar/chords/Bb/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '5x555x',
+      fingers: '203330'
+    },
+    {
       frets: 'x13121',
       fingers: '013121',
       barres: 1,

--- a/src/db/guitar/chords/C#/m7.js
+++ b/src/db/guitar/chords/C#/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '9x999x',
+      fingers: '203330'
+    },
+    {
       frets: 'x46454',
       fingers: '013121',
       barres: 4,

--- a/src/db/guitar/chords/C/m7.js
+++ b/src/db/guitar/chords/C/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '8x888x',
+      fingers: '203330'
+    },
+    {
       frets: 'x3134x',
       fingers: '021340'
     },

--- a/src/db/guitar/chords/D/m7.js
+++ b/src/db/guitar/chords/D/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: 'axaaax',
+      fingers: '203330'
+    },
+    {
       frets: 'xx0211',
       fingers: '000312'
     },

--- a/src/db/guitar/chords/E/m7.js
+++ b/src/db/guitar/chords/E/m7.js
@@ -3,6 +3,14 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '0x000x',
+      fingers: '203330'
+    },
+    {
+      frets: 'cxcccx',
+      fingers: '203330'
+    },
+    {
         frets: '022030',
         fingers: '023040'
     },

--- a/src/db/guitar/chords/Eb/m7.js
+++ b/src/db/guitar/chords/Eb/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: 'bxbbbx',
+      fingers: '203330'
+    },
+    {
       frets: 'xx1322',
       fingers: '001423'
     },

--- a/src/db/guitar/chords/F#/m7.js
+++ b/src/db/guitar/chords/F#/m7.js
@@ -3,6 +3,14 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '2x222x',
+      fingers: '203330'
+    },
+    {
+      frets: 'exeeex',
+      fingers: '203330'
+    },
+    {
       frets: '242222',
       fingers: '131111',
       barres: 2,

--- a/src/db/guitar/chords/F/m7.js
+++ b/src/db/guitar/chords/F/m7.js
@@ -3,6 +3,14 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '1x111x',
+      fingers: '203330'
+    },
+    {
+      frets: 'dxdddx',
+      fingers: '203330'
+    },
+    {
       frets: '131111',
       fingers: '131111',
       barres: 1,

--- a/src/db/guitar/chords/G/m7.js
+++ b/src/db/guitar/chords/G/m7.js
@@ -3,6 +3,10 @@ export default {
   suffix: 'm7',
   positions: [
     {
+      frets: '3x333x',
+      fingers: '203330'
+    },
+    {
       frets: '353333',
       fingers: '131111',
       barres: 3,


### PR DESCRIPTION
The `5x555x` Am7 is one of my go-to chords for jazz progressions, so this PR adds it and the equivalent shape in other keys.

I have some other chords I'd like to contribute, but opening a smaller PR first to make sure I've got the contribution process right for this repo.

Thanks for the resource! I've started using it a lot for chords references, and shared it with a few of my friends.