### PR TITLE
Add one alternative fingering for G major

### DIFF
--- a/src/db/guitar/chords/G/major.js
+++ b/src/db/guitar/chords/G/major.js
@@ -7,6 +7,10 @@ export default {
       fingers: '210003'
     },
     {
+      frets: '320003',
+      fingers: '320004'
+    },
+    {
       frets: '355433',
       fingers: '134211',
       barres: 3,


### PR DESCRIPTION
It's easier to reach and easier to transition to C major, A minor etc.

It's taught by some teachers, say, from https://www.youtube.com/watch?v=EC72QWoKKOY.