### PR TITLE
Fix tests

### DIFF
--- a/src/db/guitar/chords/F/major.js
+++ b/src/db/guitar/chords/F/major.js
@@ -10,7 +10,7 @@ export default {
     },
     {
       frets: 'xx3211',
-      fingers: 'xx3211',
+      fingers: '003211',
       barres: 1
     },
     {


### PR DESCRIPTION
The tests fail with:
```
 FAIL  src/db/guitar.test.js (11.684s)
  ● Guitar Chords › Key F › Suffix Fmajor › Positions › Fingers › The 2 position fingers array should have values higher or equal to 0

    expect(received).toBeGreaterThanOrEqual(expected)

    Expected: >= 0
    Received:    -1

```
Looking at the other chords it looks like `fingers` should contain `0`s instead of `x`s.